### PR TITLE
Added trailing slash to checking DELETE

### DIFF
--- a/ta-session/hw2scripts/runtest.py
+++ b/ta-session/hw2scripts/runtest.py
@@ -146,7 +146,7 @@ link = "http://localhost:8000/promises/"
 print("3. Checking DELETE http://localhost:8000/promises/")
 for prom in prom_old:
     print(prom)
-    link2 = link + str(prom["id"])
+    link2 = link + str(prom["id"]) + "/"
     print("\tDeleting promise {0}".format(link))
     forbidden_or_error_anon("DELETE", link2) # anonymous
 


### PR DESCRIPTION
3. Cheking DELETE에서 요청을 보내는 주소에 trailing slash가 빠져 있어 runtest.py를 여러 번 실행하거나 promises가 비어 있지 않으면 에러가 발생합니다. 수정 후 runtest.py를 여러 번 실행하거나 promises가 비어 있지 않을 때에도 올바르게 동작하는 것을 확인했습니다.

참고: https://github.com/snu-sf-class/swpp201801/issues/15#issuecomment-378850603